### PR TITLE
Set today's date as default in TimeEntryForm

### DIFF
--- a/src/components/QuickAddButton.tsx
+++ b/src/components/QuickAddButton.tsx
@@ -14,7 +14,10 @@ export function QuickAddButton({ onTimeEntryAdded }: QuickAddButtonProps) {
   const [selectedProjectId, setSelectedProjectId] = useState("");
   const [selectedActivityId, setSelectedActivityId] = useState("");
   const [hours, setHours] = useState<number | "">("");
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(() => {
+    const today = new Date();
+    return today.toISOString().split('T')[0]; // Format: YYYY-MM-DD
+  });
   const [description, setDescription] = useState("");
   const [projects, setProjects] = useState<Project[]>([]);
   const [activities, setActivities] = useState<Activity[]>([]);
@@ -57,7 +60,9 @@ export function QuickAddButton({ onTimeEntryAdded }: QuickAddButtonProps) {
     setSelectedProjectId("");
     setSelectedActivityId("");
     setHours("");
-    setDate("");
+    // Reset date to today's date
+    const today = new Date();
+    setDate(today.toISOString().split('T')[0]);
     setDescription("");
     setErrors({});
     setIsModalOpen(false);

--- a/src/components/TimeEntryForm.tsx
+++ b/src/components/TimeEntryForm.tsx
@@ -15,7 +15,10 @@ export function TimeEntryForm({
   onTimeEntryAdded,
 }: TimeEntryFormProps) {
   const [hours, setHours] = useState<number | "">("");
-  const [date, setDate] = useState("");
+  const [date, setDate] = useState(() => {
+    const today = new Date();
+    return today.toISOString().split('T')[0]; // Format: YYYY-MM-DD
+  });
   const [description, setDescription] = useState("");
   const [errors, setErrors] = useState<{ hours?: string; date?: string }>({});
   const timeTrackingService = new TimeTrackingService();
@@ -59,7 +62,9 @@ export function TimeEntryForm({
 
       // Reset form
       setHours("");
-      setDate("");
+      // Reset date to today's date
+      const today = new Date();
+      setDate(today.toISOString().split('T')[0]);
       setDescription("");
 
       // Notify parent component

--- a/src/tests/QuickAddButton.test.tsx
+++ b/src/tests/QuickAddButton.test.tsx
@@ -102,7 +102,11 @@ describe('QuickAddButton', () => {
     // Open the modal
     fireEvent.click(screen.getByText('Quick-Add Time'));
     
-    // Submit without filling form
+    // Clear date field and submit with incomplete form
+    const dateInput = screen.getByLabelText('Date');
+    fireEvent.change(dateInput, { target: { value: '' } });
+    
+    // Submit without filling required fields
     fireEvent.click(screen.getByText('Add Entry'));
     
     // Check for validation errors

--- a/src/tests/TimeEntryForm.test.tsx
+++ b/src/tests/TimeEntryForm.test.tsx
@@ -161,7 +161,25 @@ describe("TimeEntryForm", () => {
     expect(mockOnTimeEntryAdded).not.toHaveBeenCalled();
   });
 
-  test("displays error when date is not provided", () => {
+  // test("displays error when date is not provided", () => {
+  //   render(
+  //     <TimeEntryForm
+  //       activityId={mockActivityId}
+  //       onTimeEntryAdded={mockOnTimeEntryAdded}
+  //     />
+  //   );
+
+  //   const hoursInput = screen.getByLabelText("Hours");
+  //   const form = screen.getByTestId("time-entry-form");
+
+  //   fireEvent.change(hoursInput, { target: { value: "5" } });
+  //   fireEvent.submit(form);
+
+  //   expect(screen.getByText("Date is required")).toBeInTheDocument();
+  //   expect(mockOnTimeEntryAdded).not.toHaveBeenCalled();
+  // });
+
+  test("displays error when date is cleared", () => {
     render(
       <TimeEntryForm
         activityId={mockActivityId}
@@ -170,9 +188,12 @@ describe("TimeEntryForm", () => {
     );
 
     const hoursInput = screen.getByLabelText("Hours");
+    const dateInput = screen.getByLabelText("Date");
     const form = screen.getByTestId("time-entry-form");
 
     fireEvent.change(hoursInput, { target: { value: "5" } });
+    // Clear the date field
+    fireEvent.change(dateInput, { target: { value: "" } });
     fireEvent.submit(form);
 
     expect(screen.getByText("Date is required")).toBeInTheDocument();
@@ -200,7 +221,9 @@ describe("TimeEntryForm", () => {
     fireEvent.submit(form);
 
     expect(hoursInput).toHaveValue(null);
-    expect(dateInput).toHaveValue("");
+    // The date should be reset to today's date after form submission
+    const today = new Date().toISOString().split('T')[0];
+    expect(dateInput).toHaveValue(today);
     expect(descriptionInput).toHaveValue("");
   });
 });


### PR DESCRIPTION
## Description
This PR implements the feature requested in issue #3 to set today's date as the default value in the TimeEntryForm.

## Changes
- Updated the TimeEntryForm component to initialize the date field with today's date
- Modified the form reset behavior to reset to today's date instead of an empty string
- Updated tests to align with the new default behavior

## Testing
- All tests have been updated and are passing
- Verified that the date field is pre-filled with today's date when the form loads
- Confirmed that form validation still works correctly when a user clears the date field

Closes #3